### PR TITLE
Error messages for deep property

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -10,12 +10,17 @@ const errors = [
 ]
 
 describe('errorMessagesFor', () => {
-  it('returns one SchemaError for a given name', () => {
+  it('returns a list of error messages for a given name', () => {
     expect(errorMessagesFor(errors, 'b')).toEqual(['b', 'c'])
   })
 
-  it('returns null if a SchemaError can not be found for the given name', () => {
+  it('returns an empty list if no error messages can be found', () => {
     expect(errorMessagesFor(errors, 'c')).toEqual([])
+  })
+
+  it('returns a list of error messages for a deep property of the formData', async () => {
+    const err = [{ path: ['person', '0', 'email'], message: 'Invalid email' }]
+    expect(errorMessagesFor(err, 'person.0.email')).toEqual(['Invalid email'])
   })
 })
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,7 +16,9 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 }
 
 const errorMessagesFor = (errors: SchemaError[], name: string) =>
-  errors.filter(({ path }) => path.includes(name)).map(({ message }) => message)
+  errors
+    .filter(({ path }) => path.join('.') === name)
+    .map(({ message }) => message)
 
 const errorMessagesForSchema = <T extends z.AnyZodObject>(
   errors: SchemaError[],


### PR DESCRIPTION
Allows fetching error messages for deep properties in `errorMessagesFor` utility