### PR TITLE
Add InputErrors exception so we can return multiple input errors at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,25 @@ failedResult = {
 */
 ```
 
-The same can be done for environment errors by throwing an `EnvironmentError`.
+To throw several input errors in one shot you can use the pluralized version `InputErrors` as in:
+
+```ts
+const alwaysFails = makeDomainFunction(input, environment)(async () => {
+  throw new InputErrors([{message: 'Email already taken', path: 'email'}, message: 'Password too short', path: 'password'}])
+})
+
+const failedResult = await alwaysFails(someInput)
+/*
+failedResult = {
+  success: false,
+  errors: [],
+  inputErrors: [{ message: 'Email already taken', path: ['email'] }, { message: 'Password too short', path: ['password'] }],
+  environmentErrors: [],
+}
+*/
+```
+
+You can also return a custom environment error by throwing an `EnvironmentError`.
 
 ### Using error messages in the UI
 To improve DX when dealing with errors we do export a couple of utilities.

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -8,7 +8,7 @@ import {
   all,
   makeDomainFunction,
 } from './domain-functions'
-import { EnvironmentError, InputError } from './errors'
+import { EnvironmentError, InputError, InputErrors } from './errors'
 import { ErrorData, SuccessResult } from './types'
 
 describe('makeDomainFunction', () => {
@@ -167,6 +167,27 @@ describe('makeDomainFunction', () => {
       success: false,
       errors: [],
       inputErrors: [{ message: 'Custom input error', path: ['contact', 'id'] }],
+      environmentErrors: [],
+    })
+  })
+
+  it('returns multiple inputErrors when the domain function throws an InputErrors', async () => {
+    const domainFunction = makeDomainFunction(z.object({ id: z.number() }))(
+      async () => {
+        throw new InputErrors([
+          { message: 'Custom input error', path: 'contact.id' },
+          { message: 'Another input error', path: 'contact.id' },
+        ])
+      },
+    )
+
+    expect(await domainFunction({ id: 1 })).toEqual({
+      success: false,
+      errors: [],
+      inputErrors: [
+        { message: 'Custom input error', path: ['contact', 'id'] },
+        { message: 'Another input error', path: ['contact', 'id'] },
+      ],
       environmentErrors: [],
     })
   })

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -2,6 +2,7 @@ import * as z from 'zod'
 import {
   EnvironmentError,
   InputError,
+  InputErrors,
   schemaError,
   toErrorWithMessage,
 } from './errors'
@@ -67,6 +68,16 @@ const makeDomainFunction: MakeDomainFunction =
             errors: [],
             environmentErrors: [schemaError(error.message, error.path)],
             inputErrors: [],
+          }
+        }
+        if (error instanceof InputErrors) {
+          return {
+            success: false,
+            errors: [],
+            environmentErrors: [],
+            inputErrors: error.errors.map((e) =>
+              schemaError(e.message, e.path),
+            ),
           }
         }
         return {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -47,6 +47,15 @@ class InputError extends Error {
   }
 }
 
+class InputErrors extends Error {
+  errors: { message: string; path: string }[]
+
+  constructor(errors: { message: string; path: string }[]) {
+    super(`${errors.length} errors`)
+    this.errors = errors
+  }
+}
+
 class EnvironmentError extends Error {
   path: string
 
@@ -64,4 +73,5 @@ export {
   toErrorWithMessage,
   InputError,
   EnvironmentError,
+  InputErrors,
 }


### PR DESCRIPTION
# Purpose

This should close #22

# Technical details

We have decided to add a plural version `InputErrors` so the main use case maintains a simpler API and we also avoid breaking backwards compatibility.
