### PR TITLE
Make errorMessagesForSchema input type coherent with makeDomainFunction

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,7 +28,7 @@ type NestedErrors<SchemaType> = {
   [Property in keyof SchemaType]: string[] | NestedErrors<SchemaType[Property]>
 }
 
-const errorMessagesForSchema = <T extends z.AnyZodObject>(
+const errorMessagesForSchema = <T extends z.ZodTypeAny>(
   errors: SchemaError[],
   schema: T,
 ): NestedErrors<z.infer<typeof schema>> => {


### PR DESCRIPTION
## Purpose

Allow `errorMessagesForSchema` to be used with any schema used to derive a domain function.
