### PR TITLE
Reintroduce CommonJS module

### DIFF
--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -5,22 +5,14 @@ import pkg from '../package.json' assert { type: 'json' }
 await emptyDir('./npm')
 
 await build({
-  scriptModule: false,
+  scriptModule: 'cjs',
   typeCheck: false,
   declaration: true,
   entryPoints: ['./src/index.ts'],
   outDir: './npm',
   shims: {
     deno: true,
-    custom: [
-      {
-        package: {
-          name: 'node-fetch',
-          version: '^3.2.10',
-        },
-        globalNames: [{ name: 'Request' }, { name: 'FormData' }],
-      },
-    ],
+    undici: true,
   },
   mappings: {
     'https://deno.land/x/zod@v3.19.1/mod.ts': {

--- a/src/input-resolvers.ts
+++ b/src/input-resolvers.ts
@@ -1,19 +1,28 @@
 import * as qsModule from 'https://deno.land/x/deno_qs@0.0.1/mod.ts'
 
+type ParsedQs = {
+  [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[]
+}
+
+type FormDataLike = Iterable<readonly [PropertyKey, unknown]>
+type RequestLike = {
+  url: string
+  clone: () => { formData: () => Promise<FormDataLike> }
+}
+
 // Little hack to ensure we are compatible with the default export of qs in NPM
 const qs = qsModule.qs ? qsModule.qs : qsModule
 
 const inputFromSearch = (queryString: URLSearchParams) =>
-  (qs as typeof qsModule.qs).parse(queryString.toString())
+  (qs as typeof qsModule.qs).parse(queryString.toString()) as ParsedQs
 
-const inputFromFormData = (formData: FormData) =>
+const inputFromFormData = (formData: FormDataLike) =>
   inputFromSearch(new URLSearchParams(formData as URLSearchParams))
 
-const inputFromForm = async (request: {
-  clone: () => { formData: () => Promise<FormData> }
-}) => inputFromFormData(await request.clone().formData())
+const inputFromForm = async (request: RequestLike) =>
+  inputFromFormData(await request.clone().formData())
 
-const inputFromUrl = (request: { url: string }) =>
+const inputFromUrl = (request: RequestLike) =>
   inputFromSearch(new URL(request.url).searchParams)
 
 export { inputFromForm, inputFromUrl, inputFromFormData, inputFromSearch }


### PR DESCRIPTION
# Purpose

Once we moved to a module that had only the esm some code bases were broken since dependency on CommonJS modules is widespread.
