### PR TITLE
Preserve original exception when domain function is handling an unknown thrown value

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,8 +17,13 @@ function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
 }
 
 function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
-  if (isErrorWithMessage(maybeError)) return { message: maybeError.message }
-  return { message: String(maybeError) }
+  const message = isErrorWithMessage(maybeError)
+    ? maybeError.message
+    : String(maybeError)
+  return {
+    message,
+    exception: maybeError,
+  }
 }
 
 function schemaError(message: string, path: string): SchemaError {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 type ErrorWithMessage = {
   message: string
+  exception?: unknown
 }
 
 type SuccessResult<T = void> = {


### PR DESCRIPTION
## Purpose

The main use case is to handle exceptions thrown in 3rd party code without having to resort to try/catch.

Let's say you have a library called `ApiClient`. This library is used directly in domain functions, but sometimes throw errors
containing details information on why a certain api call failed.

```ts
const thisMightFail = makeDomainFunction(z.object({ id: z.number() }))(
  async () => {
    const externalData = ApiClient.call('doSomething')
    ...
  },
)
```

Since we don't know what the 3rd party code does, we could capture a failure in the `errors` field of our `ErrorResult`.
However, in the current version, the exception would be discarded and you would only have access to the `message` field of the exception.

The current work-around is to use a `try/catch` within the domain function:


```ts
const thisMightFail = makeDomainFunction(z.object({ id: z.number() }))(
  async () => {
    try {
      const externalData = ApiClient.call('doSomething')
      ...
    } catch (error) {
      throw new Error("Additional error details: " + String(error.data.someNestedDetail))
    }
    ...
  },
)
```

Since we already have a combinator to map errors (`mapError`), it would be handy to have access to all exception data and just map the error:


```ts
const thisMightFail = mapError(makeDomainFunction(z.object({ id: z.number() }))(
  async () => {
    const externalData = ApiClient.call('doSomething')
    ...
  }
  (result: ErrorData) => ({
      ...result,
      errors: result.errors.map((e) => { message: 'Additional error details: ' + String(e.?.exception?.data?.someNestedDetail) })
    })
)
```

The approach enabled by this PR has the advantage of always bubbling up the exception details, so one can always call `mapError` regardless of how the domain function is composed.

## Caveat

I used a reference to the exception instead of cloning the object. Since anything can bee thrown, I decided to keep the type unknown. So we keep the original exception opaque and avoid the complexities and risks of cloning something that we know nothing about.

I consider this a minor inconvenience since mutating the exception in place would be a terrible practice.

## Bonus points

* This enables the user to make error mappers that take advantage of the name in the `Error` type and create a custom domain error from 3rd party APIs. This could extremely useful to handle database errors automatically and turn them into domain errors for instance. 
* This would also enable automatic instrumentation to track full exceptions from domain functions applying `mapError` to already created DFs.