### PR TITLE
Invert parameters in apply-schema so we can validate schema type based on composable parameters

### DIFF
--- a/examples/arktype/src/adapters.ts
+++ b/examples/arktype/src/adapters.ts
@@ -1,6 +1,7 @@
 import {
   composable,
   Composable,
+  ComposableWithSchema,
   EnvironmentError,
   failure,
   InputError,
@@ -44,7 +45,7 @@ function withArkSchema<I, E>(
 ) {
   return function <Output>(
     handler: (input: I, environment: E) => Output,
-  ): Composable<(input?: unknown, environment?: unknown) => Awaited<Output>> {
+  ): ComposableWithSchema<Awaited<Output>> {
     return applyArkSchema(inputSchema, environmentSchema)(composable(handler))
   }
 }
@@ -73,7 +74,7 @@ function applyArkSchema<I, E>(
         return failure([...inputErrors, ...envErrors])
       }
       return fn(result.data as I, envResult.data as E)
-    } as Composable<(input?: unknown, environment?: unknown) => UnpackData<A>>
+    } as ComposableWithSchema<UnpackData<A>>
   }
 }
 

--- a/migrating-df.md
+++ b/migrating-df.md
@@ -35,7 +35,7 @@ This document will guide you through the migration process.
     - [Runtime code](#runtime-code)
 
 ## First steps
-The first thing you want to know is that the old `DomainFunction<T>` is equivalent to `Composable<(input?: unknown, environment?: unknown) => T>`. We brought the arguments to the type signature so we could type check the compositions. A [commonly requested feature](https://github.com/seasonedcc/domain-functions/issues/80) in domain-functions.
+The first thing you want to know is that the old `DomainFunction<T>` is equivalent to `Composable<(input?: unknown, environment?: unknown) => T>` (AKA `ComposableWithSchema<T>`). We brought the arguments to the type signature so we could type check the compositions. A [commonly requested feature](https://github.com/seasonedcc/domain-functions/issues/80) in domain-functions.
 
 A composable does not need a schema, but you can still use one for runtime assertion. What we used to call a Domain Function is now a Composable with [environment](./environments.md) and a schema.
 
@@ -285,7 +285,7 @@ if (result.errors.some(isInputError)) {
 #### Type utilities
 | Domain Functions | Composable Functions |
 |---|---|
-| `DomainFunction<string>` | `Composable<(input?: unknown, environment?: unknown) => string>` |
+| `DomainFunction<string>` | `ComposableWithSchema<string>` |
 | `SuccessResult<T>` | `Success<T>` |
 | `ErrorResult` | `Failure` |
 | `UnpackData<DomainFunction>` | `UnpackData<Composable>` |

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -148,7 +148,10 @@ function collect<Fns extends Record<string, Composable>>(fns: Fns) {
  * //    ^? Composable<(aNumber: number) => [string, boolean]>
  * ```
  */
-function sequence<Fns extends [Composable, ...Composable[]]>(...fns: Fns) {
+
+function sequence<Fns extends [Composable, ...Composable[]]>(
+  ...fns: Fns
+): SequenceReturn<CanComposeInSequence<Fns>> {
   return (async (...args) => {
     const [head, ...tail] = fns
 
@@ -188,12 +191,12 @@ function map<Fn extends Composable, O>(
     ...originalInput: Parameters<Fn>
   ) => O | Promise<O>,
 ): Composable<(...args: Parameters<Fn>) => O> {
-  return (async (...args) => {
+  return async (...args) => {
     const result = await fn(...args)
     if (!result.success) return failure(result.errors)
 
     return composable(mapper)(result.data, ...args)
-  }) as Composable<(...args: Parameters<Fn>) => O>
+  }
 }
 
 /**
@@ -279,11 +282,11 @@ function catchFailure<
  * }))
  * ```
  */
-function mapErrors<Fn extends Composable>(
-  fn: Fn,
+function mapErrors<P extends unknown[], Output>(
+  fn: Composable<(...args: P) => Output>,
   mapper: (err: Error[]) => Error[] | Promise<Error[]>,
-) {
-  return (async (...args) => {
+): Composable<(...args: P) => Output> {
+  return async (...args) => {
     const res = await fn(...args)
     if (res.success) return success(res.data)
     const mapped = await composable(mapper)(res.errors)
@@ -292,7 +295,7 @@ function mapErrors<Fn extends Composable>(
     } else {
       return failure(mapped.errors)
     }
-  }) as Fn
+  }
 }
 
 /**
@@ -318,15 +321,17 @@ function trace(
     result: Result<unknown>,
     ...originalInput: unknown[]
   ) => Promise<void> | void,
-) {
-  return <Fn extends Composable>(fn: Fn) =>
-    (async (...args) => {
+): <P extends unknown[], Output>(
+  fn: Composable<(...args: P) => Output>,
+) => Composable<(...args: P) => Output> {
+  return (fn) =>
+    async (...args) => {
       const originalResult = await fn(...args)
       const traceResult = await composable(traceFn)(originalResult, ...args)
       if (traceResult.success) return originalResult
 
       return failure(traceResult.errors)
-    }) as Fn
+    }
 }
 
 /**

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -1,6 +1,6 @@
 import { mapErrors } from './combinators.ts'
 import { EnvironmentError, ErrorList, InputError } from './errors.ts'
-import type { Composable, Failure, ParserSchema, Success } from './types.ts'
+import type { Composable, ComposableWithSchema, Failure, ParserSchema, Success } from './types.ts'
 import { UnpackData } from './types.ts'
 
 /**
@@ -98,7 +98,7 @@ function withSchema<I, E>(
 ) {
   return <Output>(
     handler: (input: I, environment: E) => Output,
-  ): Composable<(input?: unknown, environment?: unknown) => Awaited<Output>> =>
+  ): ComposableWithSchema<Awaited<Output>> =>
     applySchema(inputSchema, environmentSchema)(composable(handler)) as never
 }
 
@@ -146,7 +146,7 @@ function applySchema<I, E>(
         return Promise.resolve(failure([...inputErrors, ...envErrors]))
       }
       return fn(result.data as I, envResult.data as E)
-    }) as Composable<(input?: unknown, environment?: unknown) => UnpackData<A>>
+    }) as ComposableWithSchema<UnpackData<A>>
   }
 }
 

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -101,11 +101,11 @@ function fromSuccess<O, P extends any[]>(
 function withSchema<I, E>(
   inputSchema?: ParserSchema<I>,
   environmentSchema?: ParserSchema<E>,
-) {
-  return <Output>(
-    handler: (input: I, environment: E) => Output,
-  ): ComposableWithSchema<Awaited<Output>> =>
-    applySchema(inputSchema, environmentSchema)(composable(handler)) as never
+): <Output>(
+  hander: (input: I, environment: E) => Output,
+) => ComposableWithSchema<Output> {
+  return (handler) =>
+    applySchema(inputSchema, environmentSchema)(composable(handler))
 }
 
 /**

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -1,6 +1,12 @@
 import { mapErrors } from './combinators.ts'
 import { EnvironmentError, ErrorList, InputError } from './errors.ts'
-import type { Composable, ComposableWithSchema, Failure, ParserSchema, Success } from './types.ts'
+import type {
+  Composable,
+  ComposableWithSchema,
+  Failure,
+  ParserSchema,
+  Success,
+} from './types.ts'
 import { UnpackData } from './types.ts'
 
 /**
@@ -65,12 +71,12 @@ function fromSuccess<O, P extends any[]>(
   fn: Composable<(...a: P) => O>,
   onError: (errors: Error[]) => Error[] | Promise<Error[]> = (e) => e,
 ): (...args: P) => Promise<O> {
-  return (async (...args: P) => {
+  return async (...args: P) => {
     const result = await mapErrors(fn, onError)(...args)
     if (result.success) return result.data
 
     throw new ErrorList(result.errors)
-  })
+  }
 }
 
 /**
@@ -127,26 +133,32 @@ function withSchema<I, E>(
 function applySchema<I, E>(
   inputSchema?: ParserSchema<I>,
   environmentSchema?: ParserSchema<E>,
-) {
-  return <A extends Composable>(fn: A) => {
-    return ((input: I, environment: E) => {
+): <R>(
+  fn: Composable<(input?: I, environment?: E) => R>,
+) => ComposableWithSchema<R> {
+  return (fn) => {
+    return (input?: unknown, environment?: unknown) => {
       const envResult = (environmentSchema ?? alwaysUnknownSchema).safeParse(
         environment,
       )
       const result = (inputSchema ?? alwaysUnknownSchema).safeParse(input)
 
       if (!result.success || !envResult.success) {
-        const inputErrors = result.success ? [] : result.error.issues.map(
-          (error) => new InputError(error.message, error.path as string[]),
-        )
-        const envErrors = envResult.success ? [] : envResult.error.issues.map(
-          (error) =>
-            new EnvironmentError(error.message, error.path as string[]),
-        )
+        const inputErrors = result.success
+          ? []
+          : result.error.issues.map(
+              (error) => new InputError(error.message, error.path as string[]),
+            )
+        const envErrors = envResult.success
+          ? []
+          : envResult.error.issues.map(
+              (error) =>
+                new EnvironmentError(error.message, error.path as string[]),
+            )
         return Promise.resolve(failure([...inputErrors, ...envErrors]))
       }
       return fn(result.data as I, envResult.data as E)
-    }) as ComposableWithSchema<UnpackData<A>>
+    }
   }
 }
 

--- a/src/environment/combinators.ts
+++ b/src/environment/combinators.ts
@@ -27,7 +27,7 @@ function applyEnvironmentToList<
  * //    ^? ComposableWithSchema<{ aBoolean: boolean }>
  * ```
  */
-function pipe<Fns extends Composable[]>(...fns: Fns) {
+function pipe<Fns extends Composable[]>(...fns: Fns): PipeReturn<Fns> {
   return ((input: any, environment: any) =>
     A.pipe(...applyEnvironmentToList(fns, environment))(
       input,
@@ -49,7 +49,7 @@ function pipe<Fns extends Composable[]>(...fns: Fns) {
  * ```
  */
 
-function sequence<Fns extends Composable[]>(...fns: Fns) {
+function sequence<Fns extends Composable[]>(...fns: Fns): SequenceReturn<Fns> {
   return ((input: any, environment: any) =>
     A.sequence(...applyEnvironmentToList(fns, environment))(
       input,
@@ -64,7 +64,10 @@ function branch<
   Resolver extends (
     o: UnpackData<SourceComposable>,
   ) => Composable | null | Promise<Composable | null>,
->(cf: SourceComposable, resolver: Resolver) {
+>(
+  cf: SourceComposable,
+  resolver: Resolver,
+): BranchReturn<SourceComposable, Resolver> {
   return (async (...args: Parameters<SourceComposable>) => {
     const [input, environment] = args
     const result = await cf(input, environment)

--- a/src/environment/combinators.ts
+++ b/src/environment/combinators.ts
@@ -24,7 +24,7 @@ function applyEnvironmentToList<
  *   ({ aString }) => ({ aBoolean: aString == '1' }),
  * )
  * const d = environment.pipe(a, b)
- * //    ^? Composable<(input?: unknown, environment?: unknown) => { aBoolean: boolean }>
+ * //    ^? ComposableWithSchema<{ aBoolean: boolean }>
  * ```
  */
 function pipe<Fns extends Composable[]>(...fns: Fns) {
@@ -45,7 +45,7 @@ function pipe<Fns extends Composable[]>(...fns: Fns) {
  * const a = withSchema(z.number())((aNumber) => String(aNumber))
  * const b = withSchema(z.string())((aString) => aString === '1')
  * const aComposable = environment.sequence(a, b)
- * //    ^? Composable<(input?: unknown, environment?: unknown) => [string, boolean]>
+ * //    ^? ComposableWithSchema<[string, boolean]>
  * ```
  */
 

--- a/src/environment/tests/branch.test.ts
+++ b/src/environment/tests/branch.test.ts
@@ -8,7 +8,7 @@ import {
   success,
   withSchema,
 } from '../../index.ts'
-import { Composable, UnpackData } from '../../types.ts'
+import { Composable, ComposableWithSchema, UnpackData } from '../../types.ts'
 
 describe('branch', () => {
   it('should pipe a composable with arbitrary types', async () => {
@@ -40,7 +40,7 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -60,7 +60,7 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof d,
-        Composable<(input?: unknown, environment?: unknown) => number | string>
+        ComposableWithSchema<number | string>
       >
     >
 
@@ -120,7 +120,7 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -139,7 +139,7 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 

--- a/src/environment/tests/pipe.test.ts
+++ b/src/environment/tests/pipe.test.ts
@@ -8,7 +8,7 @@ import {
   success,
   withSchema,
 } from '../../index.ts'
-import type { Composable } from '../../index.ts'
+import type { Composable, ComposableWithSchema } from '../../index.ts'
 import { Internal } from '../../internal/types.ts'
 
 describe('pipe', () => {
@@ -22,7 +22,7 @@ describe('pipe', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -45,7 +45,7 @@ describe('pipe', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -69,7 +69,7 @@ describe('pipe', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -97,7 +97,7 @@ describe('pipe', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -139,7 +139,7 @@ describe('pipe', () => {
     type _R = Expect<
       Equal<
         typeof d,
-        Composable<(input?: unknown, environment?: unknown) => boolean>
+        ComposableWithSchema<boolean>
       >
     >
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export type {
   CanComposeInParallel,
   CanComposeInSequence,
   Composable,
+  ComposableWithSchema,
   Failure,
   MergeObjects,
   ParserSchema,

--- a/src/input-resolvers.ts
+++ b/src/input-resolvers.ts
@@ -128,7 +128,7 @@ function inputFromSearch(queryString: URLSearchParams): QueryStringRecord {
  * //    ^? { a: '1', b: '2' }
  * ```
  */
-function inputFromFormData(formData: FormDataLike) {
+function inputFromFormData(formData: FormDataLike): QueryStringRecord {
   return inputFromSearch(new URLSearchParams(formData as URLSearchParams))
 }
 
@@ -152,7 +152,7 @@ function inputFromFormData(formData: FormDataLike) {
  * //    ^? { a: '1', b: '2' }
  * ```
  */
-async function inputFromForm(request: RequestLike) {
+async function inputFromForm(request: RequestLike): Promise<QueryStringRecord> {
   return inputFromFormData(await request.clone().formData())
 }
 
@@ -170,9 +170,9 @@ async function inputFromForm(request: RequestLike) {
  * //    ^? { a: '1', b: '2' }
  * ```
  */
-function inputFromUrl(request: RequestLike) {
+function inputFromUrl(request: RequestLike): QueryStringRecord {
   return inputFromSearch(new URL(request.url).searchParams)
 }
 
-export type { QueryStringRecord, FormDataLike, RequestLike }
+export type { FormDataLike, QueryStringRecord, RequestLike }
 export { inputFromForm, inputFromFormData, inputFromSearch, inputFromUrl }

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -3,6 +3,7 @@ import {
   all,
   Composable,
   composable,
+  ComposableWithSchema,
   failure,
   InputError,
   success,
@@ -39,7 +40,7 @@ describe('all', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => [number, string]>
+        ComposableWithSchema<[number, string]>
       >
     >
 
@@ -71,7 +72,7 @@ describe('all', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => [string, string]>
+        ComposableWithSchema<[string, string]>
       >
     >
 

--- a/src/tests/branch.test.ts
+++ b/src/tests/branch.test.ts
@@ -7,7 +7,7 @@ import {
   UnpackData,
   withSchema,
 } from '../index.ts'
-import { Composable } from '../types.ts'
+import { Composable, ComposableWithSchema } from '../types.ts'
 import { branch } from '../combinators.ts'
 
 describe('branch', () => {
@@ -74,7 +74,7 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -111,7 +111,7 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -6,7 +6,7 @@ import {
   it,
   z,
 } from './prelude.ts'
-import type { Composable, Result, Success } from '../index.ts'
+import type { ComposableWithSchema,Composable, Result, Success } from '../index.ts'
 import {
   composable,
   EnvironmentError,
@@ -138,7 +138,7 @@ describe('withSchema', () => {
       type _R = Expect<
         Equal<
           typeof handler,
-          Composable<(input?: unknown, environment?: unknown) => string>
+          ComposableWithSchema<string>
         >
       >
 
@@ -150,7 +150,7 @@ describe('withSchema', () => {
       type _R = Expect<
         Equal<
           typeof handler,
-          Composable<(input?: unknown, environment?: unknown) => unknown>
+          ComposableWithSchema<unknown>
         >
       >
 
@@ -170,7 +170,7 @@ describe('withSchema', () => {
       type _R = Expect<
         Equal<
           typeof handler,
-          Composable<(input?: unknown, environment?: unknown) => number>
+          ComposableWithSchema<number>
         >
       >
 
@@ -182,7 +182,7 @@ describe('withSchema', () => {
       type _R = Expect<
         Equal<
           typeof handler,
-          Composable<(input?: unknown, environment?: unknown) => string>
+          ComposableWithSchema<string>
         >
       >
 
@@ -195,7 +195,7 @@ describe('withSchema', () => {
       type _R = Expect<
         Equal<
           typeof handler,
-          Composable<(input?: unknown, environment?: unknown) => number>
+          ComposableWithSchema<number>
         >
       >
 
@@ -246,7 +246,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => number[]>
+        ComposableWithSchema<number[]>
       >
     >
 
@@ -264,7 +264,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -277,7 +277,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -296,7 +296,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => number[]>
+        ComposableWithSchema<number[]>
       >
     >
 
@@ -313,7 +313,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -330,7 +330,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -348,7 +348,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -362,7 +362,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -380,7 +380,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -397,7 +397,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -419,7 +419,7 @@ describe('withSchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => never>
+        ComposableWithSchema<never>
       >
     >
 
@@ -466,7 +466,7 @@ describe('applySchema', () => {
     type _R = Expect<
       Equal<
         typeof handler,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -6,7 +6,12 @@ import {
   it,
   z,
 } from './prelude.ts'
-import type { ComposableWithSchema,Composable, Result, Success } from '../index.ts'
+import type {
+  ComposableWithSchema,
+  Composable,
+  Result,
+  Success,
+} from '../index.ts'
 import {
   composable,
   EnvironmentError,
@@ -135,24 +140,14 @@ describe('withSchema', () => {
   describe('when it has no input', () => {
     it('uses zod parser to create parse the input and call the schema function', async () => {
       const handler = withSchema()(() => 'no input!')
-      type _R = Expect<
-        Equal<
-          typeof handler,
-          ComposableWithSchema<string>
-        >
-      >
+      type _R = Expect<Equal<typeof handler, ComposableWithSchema<string>>>
 
       assertEquals(await handler(), success('no input!'))
     })
 
     it('ignores the input and pass undefined', async () => {
       const handler = withSchema()((args) => args)
-      type _R = Expect<
-        Equal<
-          typeof handler,
-          ComposableWithSchema<unknown>
-        >
-      >
+      type _R = Expect<Equal<typeof handler, ComposableWithSchema<unknown>>>
 
       assertEquals(await handler('some input'), {
         success: true,
@@ -167,24 +162,14 @@ describe('withSchema', () => {
       const parser = z.object({ id: z.preprocess(Number, z.number()) })
 
       const handler = withSchema(parser)(({ id }) => id)
-      type _R = Expect<
-        Equal<
-          typeof handler,
-          ComposableWithSchema<number>
-        >
-      >
+      type _R = Expect<Equal<typeof handler, ComposableWithSchema<number>>>
 
       assertEquals(await handler({ id: '1' }), success(1))
     })
 
     it('fails gracefully if gets something other than empty record', async () => {
       const handler = withSchema()(() => 'no input!')
-      type _R = Expect<
-        Equal<
-          typeof handler,
-          ComposableWithSchema<string>
-        >
-      >
+      type _R = Expect<Equal<typeof handler, ComposableWithSchema<string>>>
 
       assertEquals(await handler(undefined, ''), success('no input!'))
     })
@@ -192,12 +177,7 @@ describe('withSchema', () => {
     it('returns error when parsing fails', async () => {
       const parser = z.object({ id: z.preprocess(Number, z.number()) })
       const handler = withSchema(parser)(({ id }) => id)
-      type _R = Expect<
-        Equal<
-          typeof handler,
-          ComposableWithSchema<number>
-        >
-      >
+      type _R = Expect<Equal<typeof handler, ComposableWithSchema<number>>>
 
       assertEquals(
         await handler({ missingId: '1' }),
@@ -243,12 +223,7 @@ describe('withSchema', () => {
       parser,
       envParser,
     )(({ id }, { uid }) => [id, uid])
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<number[]>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<number[]>>>
 
     assertEquals(
       await handler({ id: '1' }, { uid: '2' }),
@@ -261,12 +236,7 @@ describe('withSchema', () => {
 
   it('accepts literals as input of schema functions', async () => {
     const handler = withSchema(z.number(), z.string())((n) => n + 1)
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<number>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<number>>>
 
     const result = await handler(1, 'not going to be used')
     assertEquals((result as Success<number>).data, 2)
@@ -274,12 +244,7 @@ describe('withSchema', () => {
 
   it('accepts sync functions', async () => {
     const handler = withSchema(z.number())((n) => n + 1)
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<number>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<number>>>
 
     const result = await handler(1)
     assertEquals((result as Success<number>).data, 2)
@@ -293,12 +258,7 @@ describe('withSchema', () => {
       parser,
       envParser,
     )(({ id }, { uid }) => [id, uid])
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<number[]>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<number[]>>>
 
     assertEquals(
       await handler({ id: '1' }, {}),
@@ -310,12 +270,7 @@ describe('withSchema', () => {
     const handler = withSchema(z.object({ id: z.number() }))(() => {
       throw new Error('Error')
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     const {
       errors: [err],
@@ -327,12 +282,7 @@ describe('withSchema', () => {
     const handler = withSchema(z.object({ id: z.number() }))(() => {
       throw new Error('Some message', { cause: { someUnknownFields: true } })
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     const {
       errors: [err],
@@ -345,12 +295,7 @@ describe('withSchema', () => {
     const handler = withSchema(z.object({ id: z.number() }))(() => {
       throw 'Error'
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     assertEquals(await handler({ id: 1 }), failure([new Error()]))
   })
@@ -359,12 +304,7 @@ describe('withSchema', () => {
     const handler = withSchema(z.object({ id: z.number() }))(() => {
       throw { message: 'Error' }
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     const {
       errors: [err],
@@ -377,12 +317,7 @@ describe('withSchema', () => {
     const handler = withSchema(z.object({ id: z.number() }))(() => {
       throw new InputError('Custom input error', ['contact', 'id'])
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     assertEquals(
       await handler({ id: 1 }),
@@ -394,12 +329,7 @@ describe('withSchema', () => {
     const handler = withSchema(z.object({ id: z.number() }))(() => {
       throw new EnvironmentError('Custom env error', ['currentUser', 'role'])
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     assertEquals(
       await handler({ id: 1 }),
@@ -416,12 +346,7 @@ describe('withSchema', () => {
         new EnvironmentError('Custom env error', ['currentUser', 'role']),
       ])
     })
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<never>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<never>>>
 
     assertEquals(
       await handler({ id: 1 }),
@@ -448,27 +373,20 @@ describe('applySchema', () => {
       ),
     )
     type _R = Expect<
-      Equal<
-        typeof handler,
-        Composable<
-          (input?: unknown, environment?: unknown) => readonly [number, number]
-        >
-      >
+      Equal<typeof handler, ComposableWithSchema<[number, number]>>
     >
 
-    assertEquals(await handler({ id: 1 }, { uid: 2 }), success([1, 2]))
+    assertEquals(
+      await handler({ id: 1 }, { uid: 2 }),
+      success([1, 2]) as Success<[number, number]>,
+    )
   })
 
   it('can be used as a layer on top of withSchema fn', async () => {
     const fn = withSchema(z.object({ id: z.number() }))(({ id }) => id + 1)
     const prepareSchema = z.string().transform((v) => ({ id: Number(v) }))
     const handler = applySchema(prepareSchema)(fn)
-    type _R = Expect<
-      Equal<
-        typeof handler,
-        ComposableWithSchema<number>
-      >
-    >
+    type _R = Expect<Equal<typeof handler, ComposableWithSchema<number>>>
 
     const result = await handler('1')
     assertEquals(result, success(2))

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -378,9 +378,7 @@ describe('applySchema', () => {
 
     assertEquals(
       await handler({ id: 1 }, { uid: 2 }),
-      //@TODO: can we solve this typing preserving the output readonly
-      // so we dont need to cast the success to a mutable type?
-      success([1, 2]) as Success<[number, number]>,
+      success<[number, number]>([1, 2]),
     )
   })
 

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -378,6 +378,8 @@ describe('applySchema', () => {
 
     assertEquals(
       await handler({ id: 1 }, { uid: 2 }),
+      //@TODO: can we solve this typing preserving the output readonly
+      // so we dont need to cast the success to a mutable type?
       success([1, 2]) as Success<[number, number]>,
     )
   })

--- a/src/tests/trace.test.ts
+++ b/src/tests/trace.test.ts
@@ -6,7 +6,7 @@ import {
   trace,
   withSchema,
 } from '../index.ts'
-import type { Composable } from '../index.ts'
+import type { Composable, ComposableWithSchema } from '../index.ts'
 
 describe('trace', () => {
   it('converts trace exceptions to failures', async () => {
@@ -18,7 +18,7 @@ describe('trace', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 
@@ -53,7 +53,7 @@ describe('trace', () => {
     type _R = Expect<
       Equal<
         typeof c,
-        Composable<(input?: unknown, environment?: unknown) => number>
+        ComposableWithSchema<number>
       >
     >
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ type Composable<T extends (...args: any[]) => any = (...args: any[]) => any> = (
 ) => Promise<Result<Awaited<ReturnType<T>>>>
 
 /**
- * A composable async function that catches failures.
+ * A composable async function with schema validation at runtime.
  */
 type ComposableWithSchema<O> = Composable<
   (input?: unknown, environment?: unknown) => O

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,13 @@ type Composable<T extends (...args: any[]) => any = (...args: any[]) => any> = (
 ) => Promise<Result<Awaited<ReturnType<T>>>>
 
 /**
+ * A composable async function that catches failures.
+ */
+type ComposableWithSchema<O> = Composable<
+  (input?: unknown, environment?: unknown) => O
+>
+
+/**
  * Extract the type of the returned data when a Composable is successful.
  */
 type UnpackData<T extends Composable> = Extract<
@@ -213,6 +220,7 @@ export type {
   CanComposeInParallel,
   CanComposeInSequence,
   Composable,
+  ComposableWithSchema,
   Failure,
   Last,
   MergeObjects,


### PR DESCRIPTION
rough draft, still need to update examples and docs

not so sure about this one though, perhaps it is best to keep the current solution. I'm leaving the PR open so we can contemplate de diff a while longer.