### PR TITLE
No implicit any

### DIFF
--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -33,7 +33,7 @@ function toError(maybeError: unknown): Error {
  */
 function composable<T extends Function>(
   fn: T,
-): Composable<Extract<T, (...args: any[]) => any>> {
+): Composable<T extends (...args: any[]) => any ? T : never> {
   return async (...args) => {
     try {
       // deno-lint-ignore no-explicit-any

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -31,7 +31,9 @@ function toError(maybeError: unknown): Error {
  * That function is gonna catch any errors and always return a Result.
  * @param fn a function to be used as a Composable
  */
-function composable<T extends (...args: any[]) => any>(fn: T): Composable<T> {
+function composable<T extends Function>(
+  fn: T,
+): Composable<Extract<T, (...args: any[]) => any>> {
   return async (...args) => {
     try {
       // deno-lint-ignore no-explicit-any

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -151,7 +151,7 @@ describe('withSchema', () => {
       assertEquals(await handler(), success('no input!'))
     })
 
-    it('ignores the input and pass undefined', async () => {
+    it('defaults non-declared input to unknown', async () => {
       const handler = withSchema()((args) => args)
       type _R = Expect<
         Equal<

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -49,6 +49,12 @@ describe('composable', () => {
     assertEquals(res, success(3))
   })
 
+  it('will enforce noImplicitAny', () => {
+    // @ts-expect-error: implicit any
+    const fn = composable((a) => a)
+    type _FN = Expect<Equal<typeof fn, Composable<(a: any) => any>>>
+  })
+
   it('infers the types of async functions', async () => {
     const fn = composable(asyncAdd)
     const res = await fn(1, 2)
@@ -110,7 +116,7 @@ describe('fromSuccess', () => {
     const a = composable(() => 1)
 
     const c = fromSuccess(a)
-    type _R = Expect<Equal<typeof c, () => Promise<number>>>
+    type _R = Expect<Equal<typeof c, () => Promise<1>>>
 
     assertEquals(await c(), 1)
   })


### PR DESCRIPTION
Solves #146 

This seemed to be impossible, I've done a lot of research and created [an X thread](https://x.com/gugaguichard/status/1798802769996136459) with some experts.

The solutions seemed to be:
- Forbid `any` at all which seems reasonable
- Swap `(...args: any[]) => any` for `(...args: never[]) => unknown`. This one was suggested by our contributor @jly36963 which is a thread on [TS repo itself](https://github.com/microsoft/TypeScript/issues/37595#issuecomment-604103234), and it seems nice because if you don't declare the types the arguments are gonna be never so you can't use them. I was a bit worried about some comments about problems with default arguments - as you can read in the last comment on that thread.

This morning I decided to try and use the `Function` primitive. I know we are not supposed to use it for several reasons (it could mean any constructor, or callable object, etc) but it seems to do it here.

WDYT?