### PR TITLE
apply schema

### DIFF
--- a/examples/arktype/package.json
+++ b/examples/arktype/package.json
@@ -11,7 +11,7 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "arktype": "2.0.0-dev.7",
+    "arktype": "2.0.0-dev.22",
     "composable-functions": "file:../../npm",
     "typescript": "^5.4.5"
   }

--- a/examples/arktype/pnpm-lock.yaml
+++ b/examples/arktype/pnpm-lock.yaml
@@ -1,329 +1,313 @@
-lockfileVersion: '9.0'
+lockfileVersion: 5.4
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+specifiers:
+  arktype: 2.0.0-dev.22
+  composable-functions: file:../../npm
+  tsx: ^4.7.2
+  typescript: ^5.4.5
 
-importers:
+dependencies:
+  arktype: 2.0.0-dev.22
+  composable-functions: file:../../npm
+  typescript: 5.4.5
 
-  .:
-    dependencies:
-      arktype:
-        specifier: 2.0.0-dev.22
-        version: 2.0.0-dev.22
-      composable-functions:
-        specifier: file:../../npm
-        version: file:../../npm
-      typescript:
-        specifier: ^5.4.5
-        version: 5.4.5
-    devDependencies:
-      tsx:
-        specifier: ^4.7.2
-        version: 4.7.2
+devDependencies:
+  tsx: 4.15.2
 
 packages:
 
-  '@arktype/schema@0.1.14':
+  /@arktype/schema/0.1.14:
     resolution: {integrity: sha512-NzmWveHypg3mZgn6+B4JhtlAfpQm0/oCvDGCHULWQYKHtn6UrnypotOx+fT96QNJftfaSFfptxzkwWiKPjMTow==}
+    dependencies:
+      '@arktype/util': 0.0.48
+    dev: false
 
-  '@arktype/util@0.0.48':
+  /@arktype/util/0.0.48:
     resolution: {integrity: sha512-U5FO5EUAJ4LoYtLSyAMmTf6CEVgslObfSQuua2zoK5Tv2FB3aESVQ3rdLfhuz+coRhlzlynbkmimyoQWwQT+aQ==}
+    dev: false
 
-  '@esbuild/aix-ppc64@0.19.12':
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+  /@esbuild/aix-ppc64/0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/android-arm64@0.19.12':
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.19.12':
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+  /@esbuild/android-arm/0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/android-x64@0.19.12':
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+  /@esbuild/android-arm64/0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64/0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/darwin-arm64@0.19.12':
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+  /@esbuild/darwin-arm64/0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/darwin-x64@0.19.12':
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+  /@esbuild/darwin-x64/0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/freebsd-arm64@0.19.12':
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+  /@esbuild/freebsd-arm64/0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/freebsd-x64@0.19.12':
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+  /@esbuild/freebsd-x64/0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-arm64@0.19.12':
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.19.12':
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+  /@esbuild/linux-arm/0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-ia32@0.19.12':
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+  /@esbuild/linux-arm64/0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-loong64@0.19.12':
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+  /@esbuild/linux-loong64/0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-mips64el@0.19.12':
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+  /@esbuild/linux-mips64el/0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-ppc64@0.19.12':
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+  /@esbuild/linux-ppc64/0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-riscv64@0.19.12':
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+  /@esbuild/linux-riscv64/0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-s390x@0.19.12':
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+  /@esbuild/linux-s390x/0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/linux-x64@0.19.12':
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+  /@esbuild/linux-x64/0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/netbsd-x64@0.19.12':
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+  /@esbuild/netbsd-x64/0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/openbsd-x64@0.19.12':
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+  /@esbuild/openbsd-x64/0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/sunos-x64@0.19.12':
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+  /@esbuild/sunos-x64/0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/win32-arm64@0.19.12':
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+  /@esbuild/win32-arm64/0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/win32-ia32@0.19.12':
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+  /@esbuild/win32-ia32/0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  '@esbuild/win32-x64@0.19.12':
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+  /@esbuild/win32-x64/0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
-  arktype@2.0.0-dev.22:
+  /arktype/2.0.0-dev.22:
     resolution: {integrity: sha512-oCXXi5cFaaavqPGw0QWjYI/vdOsvHLJVrDYRyCFseZqJrR3kRE4yQNI7z0VOaXyVEgGuRjXsjVvSqs3XjUb5qg==}
-
-  composable-functions@file:../../npm:
-    resolution: {directory: ../../npm, type: directory}
-
-  esbuild@0.19.12:
-    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
-  get-tsconfig@4.7.3:
-    resolution: {integrity: sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==}
-
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  tsx@4.7.2:
-    resolution: {integrity: sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-snapshots:
-
-  '@arktype/schema@0.1.14':
-    dependencies:
-      '@arktype/util': 0.0.48
-
-  '@arktype/util@0.0.48': {}
-
-  '@esbuild/aix-ppc64@0.19.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/android-arm@0.19.12':
-    optional: true
-
-  '@esbuild/android-x64@0.19.12':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.19.12':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.19.12':
-    optional: true
-
-  '@esbuild/linux-ia32@0.19.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.19.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.19.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.19.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.19.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.19.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.19.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.19.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.19.12':
-    optional: true
-
-  arktype@2.0.0-dev.22:
     dependencies:
       '@arktype/schema': 0.1.14
       '@arktype/util': 0.0.48
+    dev: false
 
-  composable-functions@file:../../npm: {}
-
-  esbuild@0.19.12:
+  /esbuild/0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.12
-      '@esbuild/android-arm': 0.19.12
-      '@esbuild/android-arm64': 0.19.12
-      '@esbuild/android-x64': 0.19.12
-      '@esbuild/darwin-arm64': 0.19.12
-      '@esbuild/darwin-x64': 0.19.12
-      '@esbuild/freebsd-arm64': 0.19.12
-      '@esbuild/freebsd-x64': 0.19.12
-      '@esbuild/linux-arm': 0.19.12
-      '@esbuild/linux-arm64': 0.19.12
-      '@esbuild/linux-ia32': 0.19.12
-      '@esbuild/linux-loong64': 0.19.12
-      '@esbuild/linux-mips64el': 0.19.12
-      '@esbuild/linux-ppc64': 0.19.12
-      '@esbuild/linux-riscv64': 0.19.12
-      '@esbuild/linux-s390x': 0.19.12
-      '@esbuild/linux-x64': 0.19.12
-      '@esbuild/netbsd-x64': 0.19.12
-      '@esbuild/openbsd-x64': 0.19.12
-      '@esbuild/sunos-x64': 0.19.12
-      '@esbuild/win32-arm64': 0.19.12
-      '@esbuild/win32-ia32': 0.19.12
-      '@esbuild/win32-x64': 0.19.12
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+    dev: true
 
-  fsevents@2.3.3:
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
-  get-tsconfig@4.7.3:
+  /get-tsconfig/4.7.5:
+    resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
     dependencies:
       resolve-pkg-maps: 1.0.0
+    dev: true
 
-  resolve-pkg-maps@1.0.0: {}
+  /resolve-pkg-maps/1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
 
-  tsx@4.7.2:
+  /tsx/4.15.2:
+    resolution: {integrity: sha512-kIZTOCmR37nEw0qxQks2dR+eZWSXydhTGmz7yx94vEiJtJGBTkUl0D/jt/5fey+CNdm6i3Cp+29WKRay9ScQUw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
     dependencies:
-      esbuild: 0.19.12
-      get-tsconfig: 4.7.3
+      esbuild: 0.21.5
+      get-tsconfig: 4.7.5
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
-  typescript@5.4.5: {}
+  /typescript/5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
+  file:../../npm:
+    resolution: {directory: ../../npm, type: directory}
+    name: composable-functions
+    version: 4.0.0
+    dev: false

--- a/examples/arktype/pnpm-lock.yaml
+++ b/examples/arktype/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       arktype:
-        specifier: 2.0.0-dev.7
-        version: 2.0.0-dev.7
+        specifier: 2.0.0-dev.22
+        version: 2.0.0-dev.22
       composable-functions:
         specifier: file:../../npm
         version: file:../../npm
@@ -24,11 +24,11 @@ importers:
 
 packages:
 
-  '@arktype/schema@0.0.7':
-    resolution: {integrity: sha512-awo14Oi98bn6pEgN7soiXvD+mQzidLgzABVO7Tpbw6xtU7+XRWp6JucSEmWLASC+fcoK0QSJxdoC+rm3iIKarQ==}
+  '@arktype/schema@0.1.14':
+    resolution: {integrity: sha512-NzmWveHypg3mZgn6+B4JhtlAfpQm0/oCvDGCHULWQYKHtn6UrnypotOx+fT96QNJftfaSFfptxzkwWiKPjMTow==}
 
-  '@arktype/util@0.0.33':
-    resolution: {integrity: sha512-MYbrLHf0tVYjxI84m0mMRISmKKVoPzv25B1/X05nePUcyPqROoDBn+hYhHpB0GqnJZQOr8UG1CyMuxjFeVbTNg==}
+  '@arktype/util@0.0.48':
+    resolution: {integrity: sha512-U5FO5EUAJ4LoYtLSyAMmTf6CEVgslObfSQuua2zoK5Tv2FB3aESVQ3rdLfhuz+coRhlzlynbkmimyoQWwQT+aQ==}
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -168,8 +168,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  arktype@2.0.0-dev.7:
-    resolution: {integrity: sha512-TeehK+ExNsvqNoEccNOMs73LcNwR9+gX9pQsoCIvZfuxrQ24nB5MUQGweAAuNSwVX7GUUU9Ad0BWGnsvD8ST+g==}
+  arktype@2.0.0-dev.22:
+    resolution: {integrity: sha512-oCXXi5cFaaavqPGw0QWjYI/vdOsvHLJVrDYRyCFseZqJrR3kRE4yQNI7z0VOaXyVEgGuRjXsjVvSqs3XjUb5qg==}
 
   composable-functions@file:../../npm:
     resolution: {directory: ../../npm, type: directory}
@@ -202,11 +202,11 @@ packages:
 
 snapshots:
 
-  '@arktype/schema@0.0.7':
+  '@arktype/schema@0.1.14':
     dependencies:
-      '@arktype/util': 0.0.33
+      '@arktype/util': 0.0.48
 
-  '@arktype/util@0.0.33': {}
+  '@arktype/util@0.0.48': {}
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -277,10 +277,10 @@ snapshots:
   '@esbuild/win32-x64@0.19.12':
     optional: true
 
-  arktype@2.0.0-dev.7:
+  arktype@2.0.0-dev.22:
     dependencies:
-      '@arktype/schema': 0.0.7
-      '@arktype/util': 0.0.33
+      '@arktype/schema': 0.1.14
+      '@arktype/util': 0.0.48
 
   composable-functions@file:../../npm: {}
 

--- a/examples/arktype/src/adapters.ts
+++ b/examples/arktype/src/adapters.ts
@@ -6,22 +6,21 @@ import {
   failure,
   InputError,
   ParserSchema,
-  UnpackData,
 } from 'composable-functions'
 import { type, Type } from 'arktype'
 
 /**
  * Approach 1: Adapt your schema to return a ParserSchema
  */
-function adapt<T extends Type>(schema: T) {
+function adapt<U, T extends Type<U>>(schema: T) {
   return {
     safeParse: (val: unknown) => {
       const result = schema(val)
-      if (result.errors) {
+      if (result instanceof type.errors) {
         return {
           success: false,
           error: {
-            issues: result.errors.map((e) => ({
+            issues: result.map((e) => ({
               path: e.path as string[],
               message: e.message,
             })),
@@ -30,7 +29,7 @@ function adapt<T extends Type>(schema: T) {
       }
       return {
         success: true,
-        data: result.data as T['infer'],
+        data: result,
       }
     },
   } as ParserSchema<T['infer']>
@@ -42,39 +41,43 @@ function adapt<T extends Type>(schema: T) {
 function withArkSchema<I, E>(
   inputSchema?: Type<I>,
   environmentSchema?: Type<E>,
-) {
-  return function <Output>(
-    handler: (input: I, environment: E) => Output,
-  ): ComposableWithSchema<Awaited<Output>> {
-    return applyArkSchema(inputSchema, environmentSchema)(composable(handler))
-  }
+): <Output>(
+  handler: (input: I, environment: E) => Output,
+) => ComposableWithSchema<Output> {
+  return (handler) =>
+    applyArkSchema(inputSchema, environmentSchema)(composable(handler))
 }
 
 function applyArkSchema<I, E>(
   inputSchema?: Type<I>,
   environmentSchema?: Type<E>,
 ) {
-  return <A extends Composable>(fn: A) => {
-    return async function (input: I, environment: E) {
+  return <R, Input, Environment>(
+    fn: Composable<(input?: Input, environment?: Environment) => R>,
+  ) => {
+    return function (input: I, environment: E) {
       const envResult = (environmentSchema ?? type('unknown'))(environment)
       const result = (inputSchema ?? type('unknown'))(input)
 
-      if (result.errors || envResult.errors) {
-        const inputErrors = Array.isArray(result.errors)
-          ? result.errors.map(
-              (error) => new InputError(error.message, error.path as string[]),
-            )
-          : []
-        const envErrors = Array.isArray(envResult.errors)
-          ? envResult.errors.map(
-              (error) =>
-                new EnvironmentError(error.message, error.path as string[]),
-            )
-          : []
+      if (result instanceof type.errors || envResult instanceof type.errors) {
+        const inputErrors =
+          result instanceof type.errors
+            ? result.map(
+                (error) =>
+                  new InputError(error.message, error.path as string[]),
+              )
+            : []
+        const envErrors =
+          envResult instanceof type.errors
+            ? envResult.map(
+                (error) =>
+                  new EnvironmentError(error.message, error.path as string[]),
+              )
+            : []
         return failure([...inputErrors, ...envErrors])
       }
-      return fn(result.data as I, envResult.data as E)
-    } as ComposableWithSchema<UnpackData<A>>
+      return fn(result as Input, envResult as Environment)
+    } as ComposableWithSchema<R>
   }
 }
 

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -109,7 +109,7 @@ function withSchema<I, E>(
   return (handler) =>
     applySchema(inputSchema, environmentSchema)(
       composable(handler),
-    ) as ComposableWithSchema<Awaited<ReturnType<typeof handler>>>
+    ) as ComposableWithSchema<any>
 }
 
 /**

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -1,14 +1,13 @@
 import { mapErrors } from './combinators.ts'
 import { EnvironmentError, ErrorList, InputError } from './errors.ts'
-import { Internal } from './internal/types.ts'
 import type {
+  ApplySchemaReturn,
   Composable,
   ComposableWithSchema,
   Failure,
   ParserSchema,
   Success,
 } from './types.ts'
-import { UnpackData } from './types.ts'
 
 /**
  * It receives any data (T) and returns a Success<T> object.
@@ -141,10 +140,7 @@ function applySchema<ParsedInput, ParsedEnvironment>(
 ) {
   return (<R, Input, Environment>(
     fn: Composable<(input?: Input, environment?: Environment) => R>,
-  ): ParsedInput extends Input
-    ? ParsedEnvironment extends Environment ? ComposableWithSchema<R>
-    : Internal.FailToCompose<ParsedEnvironment, Environment>
-    : Internal.FailToCompose<ParsedInput, Input> => {
+  ): ApplySchemaReturn<ParsedInput, ParsedEnvironment, typeof fn> => {
     return ((input?: unknown, environment?: unknown) => {
       const envResult = (environmentSchema ?? alwaysUnknownSchema).safeParse(
         environment,
@@ -162,10 +158,7 @@ function applySchema<ParsedInput, ParsedEnvironment>(
         return Promise.resolve(failure([...inputErrors, ...envErrors]))
       }
       return fn(result.data as Input, envResult.data as Environment)
-    }) as ParsedInput extends Input
-      ? ParsedEnvironment extends Environment ? ComposableWithSchema<R>
-      : Internal.FailToCompose<ParsedEnvironment, Environment>
-      : Internal.FailToCompose<ParsedInput, Input>
+    }) as ApplySchemaReturn<ParsedInput, ParsedEnvironment, typeof fn>
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,9 @@ export {
   inputFromUrl,
 } from './input-resolvers.ts'
 export type {
+  FormDataLike,
   QueryStringRecord,
   RequestLike,
-  FormDataLike,
 } from './input-resolvers.ts'
 export { serialize, serializeError } from './serializer.ts'
 export {
@@ -39,12 +39,15 @@ export {
   isInputError,
 } from './errors.ts'
 export type {
+  ApplySchemaReturn,
   BranchReturn,
   CanComposeInParallel,
   CanComposeInSequence,
   Composable,
   ComposableWithSchema,
+  FailToCompose,
   Failure,
+  IncompatibleArguments,
   MergeObjects,
   ParserSchema,
   PipeReturn,

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -5,8 +5,11 @@ namespace Internal {
     'Incompatible arguments ': true
   }
 
-  export type IsIncompatible<A, B> = Internal.CommonSubType<A, B> extends
-    IncompatibleArguments ? true
+  export type IsIncompatible<A, B> = Internal.CommonSubType<
+    A,
+    B
+  > extends IncompatibleArguments
+    ? true
     : false
 
   export type FailToCompose<A, B> = IncompatibleArguments & {
@@ -14,12 +17,10 @@ namespace Internal {
     argument2: B
   }
 
-  export type Prettify<T> =
-    & {
-      [K in keyof T]: T[K]
-      // deno-lint-ignore ban-types
-    }
-    & {}
+  export type Prettify<T> = {
+    [K in keyof T]: T[K]
+    // deno-lint-ignore ban-types
+  } & {}
 
   export type IsNever<A> =
     // prettier-ignore
@@ -40,10 +41,12 @@ namespace Internal {
   // This will not preserve union order but we don't care since this is for Composable paralel application
   export type UnionToTuple<T> = (
     (T extends any ? (t: T) => T : never) extends infer U
-      ? (U extends any ? (u: U) => any : never) extends (v: infer V) => any ? V
+      ? (U extends any ? (u: U) => any : never) extends (v: infer V) => any
+        ? V
+        : never
       : never
-      : never
-  ) extends (_: any) => infer W ? [...UnionToTuple<Exclude<T, W>>, W]
+  ) extends (_: any) => infer W
+    ? [...UnionToTuple<Exclude<T, W>>, W]
     : []
 
   export type Keys<R extends Record<string, any>> = UnionToTuple<keyof R>
@@ -56,8 +59,8 @@ namespace Internal {
     ? Head extends string
       ? rest extends string[]
         ? RecordValuesFromKeysTuple<R, rest, [...ValuesTuple, R[Head]]>
-      : never
-    : ValuesTuple
+        : never
+      : ValuesTuple
     : ValuesTuple
 
   export type Zip<
@@ -70,81 +73,90 @@ namespace Internal {
         ? restK extends string[]
           ? restV extends unknown[]
             ? Prettify<Zip<restK, restV, O & { [key in HeadK]: HeadV }>>
-          : V // in this case V has the CanComposeInParallel failure type
+            : V // in this case V has the CanComposeInParallel failure type
+          : never
         : never
       : never
-    : never
     : O
 
   export type EveryElementTakes<T extends any[], U> = T extends [
     infer HEAD,
     ...infer TAIL,
-  ] ? U extends HEAD ? EveryElementTakes<TAIL, U>
-    : FailToCompose<undefined, HEAD>
+  ]
+    ? U extends HEAD
+      ? EveryElementTakes<TAIL, U>
+      : FailToCompose<undefined, HEAD>
     : true
 
   export type SubtypesTuple<
     TupleA extends unknown[],
     TupleB extends unknown[],
     Output extends unknown[] = [],
-  > = TupleA extends [] ? [...Output, ...TupleB]
-    : TupleB extends [] ? [...Output, ...TupleA]
+  > = TupleA extends []
+    ? [...Output, ...TupleB]
+    : TupleB extends []
+    ? [...Output, ...TupleA]
     : TupleA extends [infer headA, ...infer restA]
-      ? TupleB extends [infer headB, ...infer restB]
-        ? IsIncompatible<headA, headB> extends true
-          ? FailToCompose<headA, headB>
+    ? TupleB extends [infer headB, ...infer restB]
+      ? IsIncompatible<headA, headB> extends true
+        ? FailToCompose<headA, headB>
         : SubtypesTuple<restA, restB, [...Output, CommonSubType<headA, headB>]>
-        // TupleB is partial
-        // We should handle partial case before recursion
-      : TupleB extends Partial<[infer headPartial, ...infer restPartial]>
-        ? IsIncompatible<headA, headPartial> extends true
-          ? FailToCompose<headA, headPartial>
+      : // TupleB is partial
+      // We should handle partial case before recursion
+      TupleB extends Partial<[infer headPartial, ...infer restPartial]>
+      ? IsIncompatible<headA, headPartial> extends true
+        ? FailToCompose<headA, headPartial>
         : SubtypesTuple<
-          restA,
-          Partial<restPartial>,
-          [...Output, CommonSubType<headA, Partial<headPartial>>]
-        >
+            restA,
+            Partial<restPartial>,
+            [...Output, CommonSubType<headA, Partial<headPartial>>]
+          >
       : never
     : TupleB extends [infer headBNoA, ...infer restB]
-    // TupleA is partial
-    // We should handle partial case before recursion
-      ? TupleA extends Partial<[infer headPartial, ...infer restPartial]>
-        ? IsIncompatible<headBNoA, headPartial> extends true
-          ? FailToCompose<headBNoA, headPartial>
+    ? // TupleA is partial
+      // We should handle partial case before recursion
+      TupleA extends Partial<[infer headPartial, ...infer restPartial]>
+      ? IsIncompatible<headBNoA, headPartial> extends true
+        ? FailToCompose<headBNoA, headPartial>
         : SubtypesTuple<
-          restB,
-          Partial<restPartial>,
-          [...Output, CommonSubType<headBNoA, Partial<headPartial>>]
-        >
+            restB,
+            Partial<restPartial>,
+            [...Output, CommonSubType<headBNoA, Partial<headPartial>>]
+          >
       : never
-    /*
+    : /*
      * We should continue the recursion checking optional parameters
      * We can pattern match optionals using Partial
      * We should start handling partials as soon one side of mandatory ends
      * Remove ...TupleA, ...TupleB bellow
      */
-    : TupleA extends Partial<[infer headAPartial, ...infer restAPartial]>
-      ? TupleB extends Partial<[infer headBPartial, ...infer restBPartial]>
-        ? IsIncompatible<headAPartial, headBPartial> extends true
-          ? SubtypesTuple<
+    TupleA extends Partial<[infer headAPartial, ...infer restAPartial]>
+    ? TupleB extends Partial<[infer headBPartial, ...infer restBPartial]>
+      ? IsIncompatible<headAPartial, headBPartial> extends true
+        ? SubtypesTuple<
             Partial<restAPartial>,
             Partial<restBPartial>,
             [...Output, ...Partial<[undefined]>]
           >
         : SubtypesTuple<
-          Partial<restAPartial>,
-          Partial<restBPartial>,
-          [...Output, ...Partial<[CommonSubType<headAPartial, headBPartial>]>]
-        >
+            Partial<restAPartial>,
+            Partial<restBPartial>,
+            [...Output, ...Partial<[CommonSubType<headAPartial, headBPartial>]>]
+          >
       : never
     : never
 
-  export type CommonSubType<A, B> = [A] extends [B] ? A
-    : [B] extends [A] ? B
-    : A extends { 'Incompatible arguments ': true } ? A
-    : B extends { 'Incompatible arguments ': true } ? B
+  export type CommonSubType<A, B> = [A] extends [B]
+    ? A
+    : [B] extends [A]
+    ? B
+    : A extends { 'Incompatible arguments ': true }
+    ? A
+    : B extends { 'Incompatible arguments ': true }
+    ? B
     : A extends Record<PropertyKey, unknown>
-      ? B extends Record<PropertyKey, unknown> ? Prettify<A & B>
+    ? B extends Record<PropertyKey, unknown>
+      ? Prettify<A & B>
       : FailToCompose<A, B>
     : FailToCompose<A, B>
 }

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -393,7 +393,9 @@ describe('applySchema', () => {
     const inputSchema = z.string()
 
     const handler = applySchema(inputSchema)(composable((x: 'a') => x))
-    type _R = Expect<Equal<typeof handler, Internal.FailToCompose<string, 'a'>>>
+    type _R = Expect<
+      Equal<typeof handler, Internal.FailToCompose<string, 'a' | undefined>>
+    >
     // @ts-expect-error: 'a' is not assignable to 'string'
     const _result = await handler('a')
   })

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -389,6 +389,18 @@ describe('applySchema', () => {
     )
   })
 
+  it('allow composition with unknown environment', async () => {
+    const inputSchema = z.string()
+
+    const handler = applySchema(inputSchema)(composable((x: string) => x))
+    type _R = Expect<
+      Equal<typeof handler, ComposableWithSchema<string>>
+    >
+    const result = await handler('a')
+
+    assertEquals(result, success('a'))
+  })
+
   it('fails to compose when schema result is wider than composable input', async () => {
     const inputSchema = z.string()
 

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -23,7 +23,7 @@ import {
   withSchema,
 } from '../index.ts'
 import { applySchema } from '../index.ts'
-import { Internal } from '../internal/types.ts'
+import type { Internal } from '../internal/types.ts'
 
 const add = composable((a: number, b: number) => a + b)
 const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
@@ -393,9 +393,9 @@ describe('applySchema', () => {
     const inputSchema = z.string()
 
     const handler = applySchema(inputSchema)(composable((x: 'a') => x))
-    type _R = Expect<
-      Equal<typeof handler, Internal.FailToCompose<string, 'a'>>
-    >
+    type _R = Expect<Equal<typeof handler, Internal.FailToCompose<string, 'a'>>>
+    // @ts-expect-error: 'a' is not assignable to 'string'
+    const _result = await handler('a')
   })
 
   it('can be used as a layer on top of withSchema fn', async () => {

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -7,8 +7,8 @@ import {
   z,
 } from './prelude.ts'
 import type {
-  ComposableWithSchema,
   Composable,
+  ComposableWithSchema,
   Result,
   Success,
 } from '../index.ts'
@@ -23,6 +23,7 @@ import {
   withSchema,
 } from '../index.ts'
 import { applySchema } from '../index.ts'
+import { Internal } from '../internal/types.ts'
 
 const add = composable((a: number, b: number) => a + b)
 const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
@@ -386,6 +387,15 @@ describe('applySchema', () => {
       await handler({ id: 1 }, { uid: 2 }),
       success<[number, number]>([1, 2]),
     )
+  })
+
+  it('fails to compose when schema result is wider than composable input', async () => {
+    const inputSchema = z.string()
+
+    const handler = applySchema(inputSchema)(composable((x: 'a') => x))
+    type _R = Expect<
+      Equal<typeof handler, Internal.FailToCompose<string, 'a'>>
+    >
   })
 
   it('can be used as a layer on top of withSchema fn', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,16 @@ type BranchReturn<
     : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
   : CanComposeInSequence<[SourceComposable, Composable<Resolver>]>
 
+// Re-exporting internal types
+/**
+ * A type that represents an error when composing functions with incompatible arguments.
+ */
+type IncompatibleArguments = Internal.IncompatibleArguments
+/**
+ * This is IncompatibleArguments supertype where we include the arguments that caused the incompatibility.
+ */
+type FailToCompose<A, B> = Internal.FailToCompose<A, B>
+
 export type {
   BranchReturn,
   CanComposeInParallel,
@@ -234,4 +244,6 @@ export type {
   Success,
   UnpackAll,
   UnpackData,
+  IncompatibleArguments,
+  FailToCompose,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,7 @@ type Result<T = void> = Success<T> | Failure
 type MergeObjects<Objs extends unknown[], output = {}> = Objs extends [
   infer first,
   ...infer rest,
-]
-  ? MergeObjects<rest, Internal.Prettify<Omit<output, keyof first> & first>>
+] ? MergeObjects<rest, Internal.Prettify<Omit<output, keyof first> & first>>
   : output
 
 /**
@@ -79,8 +78,7 @@ type UnpackAll<List extends Composable[]> = {
 type SequenceReturn<Fns extends unknown[]> = Fns extends [
   Composable<(...args: infer P) => any>,
   ...any,
-]
-  ? Composable<(...args: P) => UnpackAll<Fns>>
+] ? Composable<(...args: P) => UnpackAll<Fns>>
   : Fns
 
 /**
@@ -91,8 +89,7 @@ type SequenceReturn<Fns extends unknown[]> = Fns extends [
 type PipeReturn<Fns extends unknown[]> = Fns extends [
   Composable<(...args: infer P) => any>,
   ...any,
-]
-  ? Composable<(...args: P) => UnpackData<Extract<Last<Fns>, Composable>>>
+] ? Composable<(...args: P) => UnpackData<Extract<Last<Fns>, Composable>>>
   : Fns
 
 /**
@@ -103,22 +100,22 @@ type CanComposeInSequence<
   Arguments extends any[] = [],
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
   ? restA extends [
-      Composable<
-        (firstParameter: infer FirstBParameter, ...b: infer PB) => any
-      >,
-      ...unknown[],
-    ]
+    Composable<
+      (firstParameter: infer FirstBParameter, ...b: infer PB) => any
+    >,
+    ...unknown[],
+  ]
     ? Internal.IsNever<Awaited<OA>> extends true
       ? Internal.FailToCompose<never, FirstBParameter>
-      : Awaited<OA> extends FirstBParameter
+    : Awaited<OA> extends FirstBParameter
       ? Internal.EveryElementTakes<PB, undefined> extends true
         ? CanComposeInSequence<
-            restA,
-            [...Arguments, Composable<(...a: PA) => OA>]
-          >
-        : Internal.EveryElementTakes<PB, undefined>
-      : Internal.FailToCompose<Awaited<OA>, FirstBParameter>
-    : [...Arguments, Composable<(...a: PA) => OA>]
+          restA,
+          [...Arguments, Composable<(...a: PA) => OA>]
+        >
+      : Internal.EveryElementTakes<PB, undefined>
+    : Internal.FailToCompose<Awaited<OA>, FirstBParameter>
+  : [...Arguments, Composable<(...a: PA) => OA>]
   : never
 
 /**
@@ -131,11 +128,11 @@ type CanComposeInParallel<
   ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
     ? Internal.SubtypesTuple<PA, PB> extends [...infer MergedP]
       ? CanComposeInParallel<
-          [Composable<(...args: MergedP) => OB>, ...restB],
-          OriginalFns
-        >
-      : Internal.FailToCompose<PA, PB>
-    : Internal.ApplyArgumentsToFns<OriginalFns, PA>
+        [Composable<(...args: MergedP) => OB>, ...restB],
+        OriginalFns
+      >
+    : Internal.FailToCompose<PA, PB>
+  : Internal.ApplyArgumentsToFns<OriginalFns, PA>
   : never
 
 /**
@@ -167,20 +164,19 @@ type SerializableResult<T> =
 type ParserSchema<T extends unknown = unknown> = {
   safeParse: (a: unknown) =>
     | {
-        success: true
-        data: T
-      }
+      success: true
+      data: T
+    }
     | {
-        success: false
-        error: { issues: { path: Array<string | number>; message: string }[] }
-      }
+      success: false
+      error: { issues: { path: Array<string | number>; message: string }[] }
+    }
 }
 
 /**
  * Returns the last element of a tuple type.
  */
-type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L]
-  ? L
+type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L] ? L
   : never
 
 /**
@@ -194,26 +190,30 @@ type BranchReturn<
 > = CanComposeInSequence<
   [SourceComposable, Composable<Resolver>]
 > extends Composable[]
-  ? Awaited<ReturnType<Resolver>> extends null
-    ? SourceComposable
-    : CanComposeInSequence<
-        [SourceComposable, Awaited<ReturnType<Resolver>>]
-      > extends [Composable, ...any]
-    ? Composable<
-        (
-          ...args: Parameters<
-            CanComposeInSequence<
-              [SourceComposable, Awaited<ReturnType<Resolver>>]
-            >[0]
-          >
-        ) => null extends Awaited<ReturnType<Resolver>>
-          ?
-              | UnpackData<SourceComposable>
-              | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-          : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-      >
-    : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
+  ? Awaited<ReturnType<Resolver>> extends null ? SourceComposable
+  : CanComposeInSequence<
+    [SourceComposable, Awaited<ReturnType<Resolver>>]
+  > extends [Composable, ...any] ? Composable<
+      (
+        ...args: Parameters<
+          CanComposeInSequence<
+            [SourceComposable, Awaited<ReturnType<Resolver>>]
+          >[0]
+        >
+      ) => null extends Awaited<ReturnType<Resolver>> ?
+          | UnpackData<SourceComposable>
+          | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+        : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+    >
+  : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
   : CanComposeInSequence<[SourceComposable, Composable<Resolver>]>
+
+type ApplySchemaReturn<ParsedInput, ParsedEnvironment, Fn extends Composable> =
+  ParsedInput extends Parameters<Fn>[0]
+    ? ParsedEnvironment extends Parameters<Fn>[1]
+      ? ComposableWithSchema<UnpackData<Fn>>
+    : FailToCompose<ParsedEnvironment, Parameters<Fn>[1]>
+    : FailToCompose<ParsedInput, Parameters<Fn>[0]>
 
 // Re-exporting internal types
 /**
@@ -226,12 +226,15 @@ type IncompatibleArguments = Internal.IncompatibleArguments
 type FailToCompose<A, B> = Internal.FailToCompose<A, B>
 
 export type {
+  ApplySchemaReturn,
   BranchReturn,
   CanComposeInParallel,
   CanComposeInSequence,
   Composable,
   ComposableWithSchema,
+  FailToCompose,
   Failure,
+  IncompatibleArguments,
   Last,
   MergeObjects,
   ParserSchema,
@@ -244,6 +247,4 @@ export type {
   Success,
   UnpackAll,
   UnpackData,
-  IncompatibleArguments,
-  FailToCompose,
 }


### PR DESCRIPTION
We should not allow `applySchema` to take schemas that would potentially break our runtime with a wider type than what the composable takes. 