### PR TITLE
chore: Change ParserSchema type to be more conformant to both Zod and Arktype

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -169,7 +169,9 @@ type ParserSchema<T extends unknown = unknown> = {
     }
     | {
       success: false
-      error: { issues: { path: Array<string | number>; message: string }[] }
+      error: {
+        issues: ReadonlyArray<{ path: PropertyKey[]; message: string }>
+      }
     }
 }
 


### PR DESCRIPTION
By making the error.issues `readonly` we are following good practices in general.
By swapping `(string | number)` for `PropertyKey` which includes `(string | number | symbol)` we not only will conform to Zod issue but also to Arktype's path definition.

It simplifies the adaptor as suggested by @ssalbdivad therefore simplifying the ark example: #150 .
