### PR TITLE
Build a composable that always succeeds

### DIFF
--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -17,6 +17,13 @@ function success<const T>(data: T): Success<T> {
 }
 
 /**
+ * It receives any data (T) and returns a constant Composable that always succeeds
+ */
+function always<const T>(data: T): (...args: any[]) => Promise<Success<T>> {
+  return () => Promise.resolve(success(data))
+}
+
+/**
  * It receives a list of errors and returns a Failure object.
  */
 function failure(errors: Error[]): Failure {
@@ -166,4 +173,12 @@ const alwaysUnknownSchema: ParserSchema<unknown> = {
   safeParse: (data: unknown) => ({ success: true, data }),
 }
 
-export { applySchema, composable, failure, fromSuccess, success, withSchema }
+export {
+  always,
+  applySchema,
+  composable,
+  failure,
+  fromSuccess,
+  success,
+  withSchema,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  always,
   applySchema,
   composable,
   failure,


### PR DESCRIPTION
I have written this function more than a couple of times and a see some use cases in the wild but always brush it off thinking "why bother, it is so simple to reimplement".

The same argument can be used to bring it in though. It's very low complexity and it helps to keep the typing consistent.