### PR TITLE
We want to be able to throw arbitrary values when using fromSuccess

### DIFF
--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -1,4 +1,3 @@
-import { mapErrors } from './combinators.ts'
 import { ContextError, ErrorList, InputError } from './errors.ts'
 import type { Internal } from './internal/types.ts'
 import type {
@@ -83,10 +82,10 @@ function fromSuccess<O, P extends any[]>(
   onError: (errors: Error[]) => Error[] | Promise<Error[]> = (e) => e,
 ): (...args: P) => Promise<O> {
   return (async (...args: P) => {
-    const result = await mapErrors(fn, onError)(...args)
+    const result = await fn(...args)
     if (result.success) return result.data
 
-    throw new ErrorList(result.errors)
+    throw new ErrorList(await onError(result.errors))
   }) as (...args: P) => Promise<O>
 }
 

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../index.ts'
 import { applySchema } from '../index.ts'
 import type { Internal } from '../internal/types.ts'
+import { assertInstanceOf } from 'https://deno.land/std@0.206.0/assert/assert_instance_of.ts'
 
 const add = composable((a: number, b: number) => a + b)
 const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
@@ -142,6 +143,25 @@ describe('fromSuccess', () => {
     type _R = Expect<Equal<typeof c, () => Promise<1>>>
 
     assertEquals(await c(), 1)
+  })
+
+  it('allows to throw any arbitrary value', async () => {
+    const a = composable(() => {
+      throw new Error('Some error')
+    })
+
+    class CustomError {}
+    const c = fromSuccess(a, () => {
+      throw new CustomError()
+    })
+    type _R = Expect<Equal<typeof c, () => Promise<never>>>
+
+    try {
+      await c()
+      throw new Error('should have thrown on the line above')
+    } catch (e) {
+      assertInstanceOf(e, CustomError)
+    }
   })
 
   it('allows to change the errors list', () => {


### PR DESCRIPTION
This feature is still undocumented so use at your own peril.
The idea is to be able to map a composable to any function you might write with a traditional throw/catch syntax.