### PR TITLE
Deprecate the environment namespace in favor of context

### DIFF
--- a/src/context/environment.ts
+++ b/src/context/environment.ts
@@ -1,0 +1,13 @@
+import { branch, pipe, sequence } from './index.ts'
+
+/**
+ * @deprecated use `import { context } from 'composable-functions'` instead
+ */
+const environment = {
+  branch,
+  pipe,
+  sequence,
+}
+
+// deno-lint-ignore verbatim-module-syntax
+export { environment }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,5 @@ export type {
 } from './types.ts'
 
 // FUNCTIONS WITH CONTEXT
-/**
- * @deprecated use `import { context }` instead
- */
-export * as environment from './context/index.ts'
+export { environment } from './context/environment.ts'
 export * as context from './context/index.ts'


### PR DESCRIPTION
This lil change will make the editors show the `environment` namespace as deprecated:

![Screenshot 2024-06-27 at 18 37 56](https://github.com/seasonedcc/composable-functions/assets/566971/ab5bf570-0a6d-48eb-ae54-3679078d218a)
