### PR TITLE
Make the Composable type easier on the eyes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,8 @@ type MergeObjects<Objs extends unknown[], output = {}> = Objs extends [
   : output
 
 /**
- * An untagged composable async function that catches failures.
- * We only use this type to make the Composable type neater looking.
+ * A composable async function that catches failures.
+ * We only use this type to make the Composable type neater looking, use `Composable` instead.
  * It does not need to be exported by the library.
  */
 type ComposableFunction<T extends Internal.AnyFn = Internal.AnyFn> = {
@@ -270,7 +270,6 @@ export type {
   CanComposeInParallel,
   CanComposeInSequence,
   Composable,
-  ComposableFunction,
   ComposableWithSchema,
   FailToCompose,
   Failure,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,9 +46,12 @@ type MergeObjects<Objs extends unknown[], output = {}> = Objs extends [
  * We only use this type to make the Composable type neater looking.
  * It does not need to be exported by the library.
  */
-type ComposableFunction<T extends Internal.AnyFn = Internal.AnyFn> = (
-  ...args: Parameters<T>
-) => Promise<Result<Awaited<ReturnType<T>>>>
+type ComposableFunction<T extends Internal.AnyFn = Internal.AnyFn> = {
+  (
+    ...args: Parameters<T>
+  ): Promise<Result<Awaited<ReturnType<T>>>>
+  kind: 'composable'
+}
 
 /**
  * A composable async function that catches failures.
@@ -56,10 +59,7 @@ type ComposableFunction<T extends Internal.AnyFn = Internal.AnyFn> = (
 type Composable<T extends Internal.AnyFn = Internal.AnyFn> = T extends {
   kind: 'composable'
 } ? T
-  : ComposableFunction<T> & {
-    kind: 'composable'
-  }
-
+  : ComposableFunction<T>
 /**
  * A composable async function with schema validation at runtime.
  */


### PR DESCRIPTION
Before the type `Composable` would be diplayed as:
```typescript 
const f = composable((x: number) => x)
//    ^? ((x: number) => Promise<Result<number>>) & { kind: "composable"; }
```
This was really bothering me when using the library, particularly when dealing with composables with an already cluttered return type.
After this PR it resolves to a new type we don't export called `ComposableFunction`:

```typescript 
const f = composable((x: number) => x)
//    ^? ComposableFunction<(x: number) => number>
```
