### PR TITLE
Include original input when mapping errors

### DIFF
--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -1,6 +1,6 @@
 // ex. scripts/build_npm.ts
 import { build, emptyDir } from 'https://deno.land/x/dnt@0.40.0/mod.ts'
-import pkg from '../deno.json' assert { type: 'json' }
+import pkg from '../deno.json' with { type: 'json' }
 
 await emptyDir('./npm')
 

--- a/src/tests/map-errors.test.ts
+++ b/src/tests/map-errors.test.ts
@@ -59,6 +59,21 @@ describe('mapErrors', () => {
     assertEquals(res.errors[0].message, 'a is 1!!!')
   })
 
+  it('maps using the original input', async () => {
+    const fn = mapErrors(faultyAdd, (_, a, b) => {
+      throw new Error('result would be ' + (a + b))
+    })
+    const res = await fn(1, 2)
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => number>>
+    >
+    type _R = Expect<Equal<typeof res, Result<number>>>
+
+    assertEquals(res.success, false)
+    assertEquals(res.errors[0].message, 'result would be 3')
+  })
+
   it('accepts an async mapper', async () => {
     const fn = mapErrors(
       faultyAdd,


### PR DESCRIPTION
Just came across a use case for this (in case you want to persist or log the input data for troubleshooting purposes.

It also keeps parity with the `map` interface.