### PR TITLE
Performant `merge` and remove test duplication

### DIFF
--- a/src/tests/types.test.ts
+++ b/src/tests/types.test.ts
@@ -21,23 +21,6 @@ namespace Last {
   type test3 = Expect<Equal<Subject.Last<[]>, never>>
 }
 
-namespace MergeObjects {
-  const obj1 = { a: 1, b: 2 } as const
-  const obj2 = {}
-  const obj3 = { c: 3, d: 4 } as const
-
-  type Result = Subject.MergeObjects<[typeof obj1, typeof obj2, typeof obj3]>
-
-  type test1 = Expect<Equal<keyof Result, 'a' | 'b' | 'c' | 'd'>>
-  type test2 = Expect<Equal<Result[keyof Result], 1 | 2 | 3 | 4>>
-}
-
-namespace Last {
-  type test1 = Expect<Equal<Subject.Last<[1, 2, 3]>, 3>>
-  type test2 = Expect<Equal<Subject.Last<[1]>, 1>>
-  type test3 = Expect<Equal<Subject.Last<[]>, never>>
-}
-
 namespace PipeReturn {
   type test = Expect<
     Equal<

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,11 @@ type Success<T = void> = {
 type Result<T = void> = Success<T> | Failure
 
 /**
+ * An efficient way to merge two objects. By @ahejlsberg himself.
+ */
+type Merge<T, U> = keyof T & keyof U extends never ? T & U
+  : Omit<T, keyof T & keyof U> & U
+/**
  * Merges the data types of a list of objects.
  * @example
  * type MyObjs = [
@@ -38,7 +43,7 @@ type Result<T = void> = Success<T> | Failure
 type MergeObjects<Objs extends unknown[], output = {}> = Objs extends [
   infer first,
   ...infer rest,
-] ? MergeObjects<rest, Internal.Prettify<Omit<output, keyof first> & first>>
+] ? MergeObjects<rest, Merge<output, first>>
   : output
 
 /**


### PR DESCRIPTION
I'm just removing a duplicated test and adding a `merge` type written by [ahejlsberg himself](https://x.com/colinhacks/status/1912641412669272410).