### PR TITLE
Add toString method to custom error classes for improved error reporting

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,6 +17,10 @@ class InputError extends Error {
     this.name = 'InputError'
     this.path = path
   }
+
+  override toString(): string {
+    return `${this.name}: ${this.message} (path: ${this.path.join('.')})`
+  }
 }
 
 /**
@@ -39,6 +43,10 @@ class EnvironmentError extends Error {
     this.name = 'EnvironmentError'
     this.path = path
   }
+
+  override toString(): string {
+    return `${this.name}: ${this.message} (path: ${this.path.join('.')})`
+  }
 }
 
 /**
@@ -60,6 +68,10 @@ class ContextError extends Error {
     this.name = 'ContextError'
     this.path = path
   }
+
+  override toString(): string {
+    return `${this.name}: ${this.message} (path: ${this.path.join('.')})`
+  }
 }
 
 /**
@@ -77,6 +89,12 @@ class ErrorList extends Error {
     super('ErrorList')
     this.name = 'ErrorList'
     this.list = errors
+  }
+
+  override toString(): string {
+    return `${this.name}: [\n  ${
+      this.list.map((err) => err.toString()).join(',\n  ')
+    }\n]`
   }
 }
 


### PR DESCRIPTION
**Description:**

This pull request improves the logging and reporting of custom errors (`InputError`, `EnvironmentError`, `ContextError`, and `ErrorList`) by overriding their `toString()` methods.

**Problem:**

Currently, when these custom errors are thrown and logged, or captured by services like Sentry, they often only display generic information (e.g., "ErrorList" or just the basic error message). This lacks crucial context, such as the specific path for input/context errors or the individual errors within an `ErrorList`, making debugging and issue resolution more difficult.

**Solution:**

The `toString()` method for each custom error class has been overridden to provide a more detailed and informative string representation:

*   `InputError`, `EnvironmentError`, and `ContextError` now include their respective `path` in the string output (e.g., `InputError: Invalid input (path: user.name)`).
*   `ErrorList` now includes the string representation of each error it contains, making it easy to see all underlying issues at a glance.

**Benefits:**

*   **Improved Debuggability:** Error logs will now contain more specific information, allowing developers to quickly identify the source and nature of problems.
*   **Enhanced Sentry Reporting:** Services like Sentry will receive more detailed error messages, leading to better grouping and understanding of issues.
*   **Clearer Error Propagation:** When errors are propagated, their string representation will carry more context, aiding in understanding the error flow.

This change ensures that when these errors occur, the logged output provides immediate and actionable insights, significantly speeding up the debugging process.
