### PR TITLE
Add Unequal type utility for negative type checks

### DIFF
--- a/src/test.d.ts
+++ b/src/test.d.ts
@@ -3,3 +3,6 @@ type Equal<A, B> =
   // prettier-ignore
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true
     : [A, 'should equal', B]
+
+type Unequal<A, B> =
+  Equal<A, B> extends true ? [A, 'should not equal', B] : true

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -81,6 +81,9 @@ describe('composable', () => {
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
     >
+    type _FN2 = Expect<
+      Unequal<typeof fn, Composable<(a: number, b: number) => Promise<number>>>
+    >
     type _R = Expect<Equal<typeof res, Result<number>>>
 
     assertEquals(res, success(3))


### PR DESCRIPTION
## Summary
- introduce a new `Unequal` type helper to assert type inequality
- start using `Unequal` in constructor tests for async functions

## Testing
- `deno test --allow-env --allow-net src` *(fails: `deno` command not found)*