### PR TITLE
Fix async composable type inference

### DIFF
--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -36,12 +36,17 @@ function toError(maybeError: unknown): Error {
  * That function is gonna catch any errors and always return a Result.
  * @param fn a function to be used as a Composable
  */
-function composable<T extends Function>(
+function composable<T extends (...args: any[]) => any>(
   fn: T,
-): Composable<T extends Internal.AnyFn ? T : never> {
+): Composable<
+  T extends Internal.AnyFn ? (...args: Parameters<T>) => Awaited<ReturnType<T>>
+    : never
+> {
   if ('kind' in fn && fn.kind === 'composable') {
     return fn as unknown as Composable<
-      T extends Internal.AnyFn ? T : never
+      T extends Internal.AnyFn
+        ? (...args: Parameters<T>) => Awaited<ReturnType<T>>
+        : never
     >
   }
   const callable = async (...args: any[]) => {
@@ -57,7 +62,11 @@ function composable<T extends Function>(
     }
   }
   callable.kind = 'composable' as const
-  return callable as Composable<T extends Internal.AnyFn ? T : never>
+  return callable as Composable<
+    T extends Internal.AnyFn
+      ? (...args: Parameters<T>) => Awaited<ReturnType<T>>
+      : never
+  >
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix `composable` return type so async functions drop `Promise`

## Testing
- `deno lint` *(fails: Import ... failed)*
- `deno task test` *(fails: No route to host)*